### PR TITLE
[FEAT] Silence ffmpeg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,8 @@ fn main() {
             .expect("failed to wait on grim");
         Command::new("ffmpeg")
             .args(&[
+                "-loglevel",
+                "fatal",
                 "-i",
                 &screenshot_path_string,
                 "-vf",


### PR DESCRIPTION
Currently the call to `ffmpeg` is very noisy as it prints a lot of information such as the build configuration.
This change sets the loglevel to 8 which according to `man ffmpeg` shows fatal errors only which I think is appropriate here. -8 would also be possible to silence everything but this might hide important information when something goes wrong.

I noticed the noisyness when trying out `swaylock-blur` in a terminal which is suboptimal. Also consider that the log output slows down the process ever so slightly which is at least mildly important when locking the screen.